### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/codegen/pom.xml
+++ b/codegen/pom.xml
@@ -80,7 +80,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.6</jdk.version>
         <commons-lang3.version>3.1</commons-lang3.version>
-        <common-collections.version>3.2.1</common-collections.version>
+        <common-collections.version>3.2.2</common-collections.version>
         <commons-io.version>2.4</commons-io.version>
         <guava.version>13.0.1</guava.version>
         <velocity.version>1.7</velocity.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
